### PR TITLE
Export type used for tagging erlang maps

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -340,9 +340,9 @@ func readBin(r io.Reader) (bintag, error) {
 
 // maptag is a specific type that allows us to override the print statement to always ensure
 // that the keys are printed in order
-type maptag map[Term]Term
+type Map map[Term]Term
 
-func (m maptag) String() string {
+func (m Map) String() string {
 
 	// Cast back to the map type
 	var keys []string
@@ -368,7 +368,7 @@ func (m maptag) String() string {
 	return r
 }
 
-func readMap(r io.Reader) (maptag, error) {
+func readMap(r io.Reader) (Map, error) {
 	pairs, err := read4(r)
 	if err != nil {
 		return nil, err
@@ -388,7 +388,7 @@ func readMap(r io.Reader) (maptag, error) {
 		m[key] = value
 	}
 
-	return maptag(m), nil
+	return Map(m), nil
 }
 
 func readComplex(r io.Reader) (Term, error) {

--- a/decode_test.go
+++ b/decode_test.go
@@ -249,7 +249,7 @@ func TestDecodeNoCompression(t *testing.T) {
 			97, 108, 117, 101, 49, 107, 0, 4, 107, 101, 121, 50, 107, 0, 6, 118,
 			97, 108, 117, 101, 50, 107, 0, 4, 107, 101, 121, 51, 107, 0, 6, 118,
 			97, 108, 117, 101, 51,
-		}, maptag{"key1": "value1", "key2": "value2", "key3": "value3"})
+		}, Map{"key1": "value1", "key2": "value2", "key3": "value3"})
 
 	// Pid
 	pid := Pid{}


### PR DESCRIPTION
Otherwise there is no way to use it from outside, except for reflect
Value's `MapIndex()` and `MapKeys()`

Similar `bintag` type doesn't have this problem, as it provides
`fmt.Stringer` interface. But having only the Stringer is definitely
not enough for maps.